### PR TITLE
Fix Alphaworks link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -35,7 +35,7 @@
 
         <section id="building">
             <h3>Building</h3>
-            <p>Currently Head of Product at <a href="alphaworks.net">Alphaworks</a>, a betaworks-founded platform for investing in startups. Previously: DrawQuest, Canvas, Ning.</p>
+            <p>Currently Head of Product at <a href="https://alphaworks.net">Alphaworks</a>, a betaworks-founded platform for investing in startups. Previously: DrawQuest, Canvas, Ning.</p>
         </section>
 
         <section id="advising">


### PR DESCRIPTION
Missing protocol caused it to link to: `http://www.nsbarr.com/alphaworks.net`
